### PR TITLE
Fix endless loop whe generating uppercase char w/o ambiguous

### DIFF
--- a/src/PWGen.php
+++ b/src/PWGen.php
@@ -291,8 +291,8 @@ class PWGen
                 if ($this->pwgen_flags & self::PW_UPPERS) {
                     if (($first || $flags & self::CONSONANT) &&
                         (self::my_rand(0, 9) < 2) &&
-                        ($this->pwgen_flags & self::PW_AMBIGUOUS) &&
-                        strpos(self::$pw_ambiguous, strtoupper($this->password[$c])) === false) {
+                        (($this->pwgen_flags & self::PW_AMBIGUOUS) ||
+                        strpos(self::$pw_ambiguous, strtoupper($this->password[$c])) === false)) {
                         $this->password[$c] = strtoupper($this->password[$c]);
                         $feature_flags &= ~self::PW_UPPERS;
                     }

--- a/tests/PWGen/PWGenTest.php
+++ b/tests/PWGen/PWGenTest.php
@@ -113,7 +113,7 @@ class PWGenTest extends TestCase
 
     public function testGenerateAmbiguous()
     {
-        $pwgen = new PWGen(20, false, false, false, true);
+        $pwgen = new PWGen(20, false, false, true, true);
 
         $this->assertEquals(20, $pwgen->getLength());
         $this->assertTrue($pwgen->hasAmbiguous());


### PR DESCRIPTION
fix #13

Also modify testGenerateAmbiguous, ambiguous characters come from the
uppercase set, thus it required to enable $capitalize in order to get
some ambiguous ones.

---

Also see discussion in #13, this is a quick fix for the endless loop, but tests may be changed