### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 php:
+  - '5.4'
+  - '5.5'
   - '5.6'
   - '7.0'
   - '7.1'
@@ -9,9 +11,11 @@ php:
 
 matrix:
   allow_failures:
-    - php: 7.2
     - php: hhvm
     - php: nightly
+  include:
+    - php: 5.3
+      dist: precise
 
 before_script:
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,10 @@
     "autoload": {
         "psr-4": { "PWGen\\": "src/" }
     },
+    "autoload-dev": {
+        "psr-4": { "PWGen\\Tests\\": "tests/PWGen" }
+    },
     "require-dev": {
-        "phpunit/phpunit": "^6.4"
+        "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5"
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,4 +10,10 @@
         </testsuite>
     </testsuites>
 
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
+
 </phpunit>

--- a/tests/PWGen/PWGenTest.php
+++ b/tests/PWGen/PWGenTest.php
@@ -17,6 +17,7 @@ class PWGenTest extends TestCase
     {
         $pwgen = new PWGen();
         $pwgen->setAmbiguous(true);
+
         $this->assertTrue($pwgen->hasAmbiguous());
     }
 
@@ -24,21 +25,37 @@ class PWGenTest extends TestCase
     {
         $pwgen = new PWGen();
         $pwgen->setCapitalize(true);
+
         $this->assertTrue($pwgen->hasCapitalize());
     }
 
-    // TODO: add more tests for set length (<5, <2 and <1)
-    public function testSetLength()
+    public function setLengthProvider()
+    {
+        return array(
+            array(-1, 8),
+            array(4, 4),
+            array(2, 2),
+            array(1, 1),
+            array(20, 20),
+        );
+    }
+
+    /**
+     * @dataProvider setLengthProvider
+     */
+    public function testSetLength($pwdLength, $expectedLength)
     {
         $pwgen = new PWGen();
-        $pwgen->setLength(20);
-        $this->assertEquals(20, $pwgen->getLength());
+        $pwgen->setLength($pwdLength);
+
+        $this->assertEquals($expectedLength, $pwgen->getLength());
     }
 
     public function testSetNoVovels()
     {
         $pwgen = new PWGen();
         $pwgen->setNoVovels(true);
+
         $this->assertTrue($pwgen->hasNoVovels());
     }
 
@@ -46,6 +63,7 @@ class PWGenTest extends TestCase
     {
         $pwgen = new PWGen();
         $pwgen->setNumerals(true);
+
         $this->assertTrue($pwgen->hasNumerals());
     }
 
@@ -53,6 +71,7 @@ class PWGenTest extends TestCase
     {
         $pwgen = new PWGen();
         $pwgen->setSecure(true);
+
         $this->assertTrue($pwgen->isSecure());
     }
 
@@ -60,6 +79,7 @@ class PWGenTest extends TestCase
     {
         $pwgen = new PWGen();
         $pwgen->setSymbols(true);
+
         $this->assertTrue($pwgen->hasSymbols());
     }
 
@@ -72,7 +92,7 @@ class PWGenTest extends TestCase
 
         $pass = $pwgen->generate();
 
-        $this->assertTrue(is_string($pass));
+        $this->assertInternalType('string', $pass);
         $this->assertEquals(20, strlen($pass));
         $this->assertRegExp('/[a-z]/', $pass); // Alpha lower
         $this->assertRegExp('/[A-Z]/', $pass); // Alpha upper
@@ -89,7 +109,7 @@ class PWGenTest extends TestCase
 
         $pass = $pwgen->generate();
 
-        $this->assertTrue(is_string($pass));
+        $this->assertInternalType('string', $pass);
         $this->assertEquals(20, strlen($pass));
         $this->assertRegExp('/[a-z]/', $pass); // Alpha lower
         $this->assertRegExp('/[A-Z]/', $pass); // Alpha upper
@@ -106,7 +126,7 @@ class PWGenTest extends TestCase
 
         $pass = $pwgen->generate();
 
-        $this->assertTrue(is_string($pass));
+        $this->assertInternalType('string', $pass);
         $this->assertEquals(20, strlen($pass));
         $this->assertRegExp('/[a-z]/', $pass); // Alpha lower
         $this->assertNotRegExp('/[A-Z]/', $pass); // Alpha NOT upper
@@ -122,7 +142,7 @@ class PWGenTest extends TestCase
 
         $pass = $pwgen->generate();
 
-        $this->assertTrue(is_string($pass));
+        $this->assertInternalType('string', $pass);
         $this->assertEquals(20, strlen($pass));
         $this->assertRegExp('/[a-z]/', $pass); // Alpha lower
         $this->assertRegExp('/[A-Z]/', $pass); // Alpha upper
@@ -139,7 +159,7 @@ class PWGenTest extends TestCase
 
         $pass = $pwgen->generate();
 
-        $this->assertTrue(is_string($pass));
+        $this->assertInternalType('string', $pass);
         $this->assertEquals(20, strlen($pass));
         $this->assertRegExp('/[a-z]/', $pass); // Alpha lower
         $this->assertRegExp('/[A-Z]/', $pass); // Alpha NOT upper
@@ -157,7 +177,7 @@ class PWGenTest extends TestCase
 
         $pass = $pwgen->generate();
 
-        $this->assertTrue(is_string($pass));
+        $this->assertInternalType('string', $pass);
         $this->assertEquals(20, strlen($pass));
         $this->assertRegExp('/[a-z]/', $pass); // Alpha lower
         $this->assertRegExp('/[A-Z]/', $pass); // Alpha upper
@@ -174,7 +194,7 @@ class PWGenTest extends TestCase
 
         $pass = $pwgen->generate();
 
-        $this->assertTrue(is_string($pass));
+        $this->assertInternalType('string', $pass);
         $this->assertEquals(20, strlen($pass));
         $this->assertRegExp('/[a-z]/', $pass); // Alpha lower
         $this->assertNotRegExp('/[A-Z]/', $pass); // Alpha NOT upper
@@ -182,5 +202,33 @@ class PWGenTest extends TestCase
         $this->assertRegExp('/[' . preg_quote($pwgen->getSymbols(), '/') . ']/', $pass); // Symbols
     }
 
-    // TODO: ALL possible combinations should be tested!!!
+    public function testBlacklistSymbol()
+    {
+        $pwgen = new PWGen();
+        $pwgen->blacklistSymbol(array('@', '#', '$'));
+
+        $this->assertSame("!\"%&'()*+,-./:;<=>?[\]^_`{|}~", $pwgen->getSymbols());
+    }
+
+    public function testGetAmbiguous()
+    {
+        $pwgen = new PWGen();
+        $pwgen->setAmbiguous(true);
+
+        $this->assertSame('B8G6I1l0OQDS5Z2', $pwgen->getAmbiguous());
+    }
+
+    public function testMyRandOnInvalidRange()
+    {
+        $pwgen = new PWGen();
+
+        $this->assertFalse($pwgen->my_rand(100, 0));
+    }
+
+    public function testToString()
+    {
+        $pwgen = new PWGen();
+
+        $this->assertInternalType('string', (string) $pwgen);
+    }
 }


### PR DESCRIPTION
# Changed log
- Add more tests.
- Remove `php-7.2` from `allow_failures` setting.
- Set the correct assertion.
- Add the `php-5.3`, `php-5.4` and `php-5.5` tests in Travis CI build.
- Set the different PHPUnit version to support different PHP versions.