### PR TITLE
allow method chaining with blacklistSymbol() func

### DIFF
--- a/src/PWGen.php
+++ b/src/PWGen.php
@@ -533,6 +533,8 @@ class PWGen
             unset($symbolArray[$index]);
         }
         self::$pw_symbols = implode('', $symbolArray);
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Currently call to blacklistSymbol must be done on an instance in php
variable :

	$gen = new \PWGen\PWGen($size);
	$gen->blacklistSymbol(['<', '>']);
	echo $gen->setAmbiguous(true)->setSymbols(true)->generate();

Return $this in blacklistSymbol method would allow more straightforward
construction as:

	$gen = new \PWGen\PWGen($size);
	echo $gen->blacklistSymbol(['<', '>'])->setAmbiguous(!$noAmbiguous)->setSymbols(true)->generate();

Or even oneliner :

	echo (new \PWGen\PWGen($size))->blacklistSymbol(['<', '>'])->setAmbiguous(!$noAmbiguous)->setSymbols(true)->generate();

The other possibility is to change blacklistSymbol to a static method, as it already work only on static variable members and multiple instances of PWGen would share the symbol list

Would you prefer this later solution? I can come back with this one